### PR TITLE
Update NtApiDotNet to v1.1.9 and add fallback to GetProcessName.

### DIFF
--- a/FindZombieHandles/FindZombieHandles.csproj
+++ b/FindZombieHandles/FindZombieHandles.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NtApiDotNet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\NtApiDotNet.1.1.8\lib\net45\NtApiDotNet.dll</HintPath>
+      <HintPath>packages\NtApiDotNet.1.1.9\lib\net45\NtApiDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -52,7 +52,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/FindZombieHandles/Program.cs
+++ b/FindZombieHandles/Program.cs
@@ -65,6 +65,17 @@ namespace FindZombieHandles
                     else
                         return process.Result.Name;
                 }
+                else
+                {
+                    try
+                    {
+                        return Process.GetProcessById(process_id).ProcessName;
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                }
+
                 return "Unknown";
             }
         }

--- a/FindZombieHandles/packages.config
+++ b/FindZombieHandles/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NtApiDotNet" version="1.1.8" targetFramework="net461" />
+  <package id="NtApiDotNet" version="1.1.9" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
NtApiDotNet v1.1.9 contains a fix for accessing the IsDeleting status Windows 7 and 8.X. This patch updates to that version from NuGet. This patch also contains a change to GetProcessName to fallback to the .NET Process class to extract the name of the process if it can't be opened directly. The Process class can get the basic name of a process without admin privileges.