### PR TITLE
Add Application Manifests

### DIFF
--- a/cfg/VAllocStress/VAllocStress.cpp
+++ b/cfg/VAllocStress/VAllocStress.cpp
@@ -150,14 +150,11 @@ int main(int argc, char* argv[])
 	if (alloc_size > alloc_stride)
 		alloc_stride = alloc_size;
 
-#ifdef PORTABLE_CODE
 	DWORD extra_flags = 0;
 	// This call requires a Windows 10 compatibility manifest, FWIW.
 	if (IsWindows10OrGreater()) // Maybe should be checking 8.1?
 		extra_flags = PAGE_TARGETS_INVALID; // Not valid on Windows 7.
-#else
-	DWORD extra_flags = PAGE_TARGETS_INVALID; // Not valid on Windows 7.
-#endif
+
 	constexpr auto null_char = static_cast<char*>(nullptr);
 	size_t alloc_count = 0;
 	for (size_t offset = alloc_stride; offset < 256 * one_tb && alloc_count < num_allocs; offset += alloc_stride)

--- a/cfg/VAllocStress/VAllocStress.manifest
+++ b/cfg/VAllocStress/VAllocStress.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and Windows Server 2016 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+
+      <!-- Windows 8.1 and Windows Server 2012 R2 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}}"/>
+
+      <!-- Windows 8 and Windows Server 2012 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+
+      <!-- Windows 7 and Windows Server 2008 R2 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+
+      <!-- Windows Vista and Windows Server 2008 -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/cfg/VAllocStress/VAllocStress.manifest
+++ b/cfg/VAllocStress/VAllocStress.manifest
@@ -6,7 +6,7 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
 
       <!-- Windows 8.1 and Windows Server 2012 R2 -->
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
 
       <!-- Windows 8 and Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>

--- a/cfg/VAllocStress/VAllocStress.vcxproj
+++ b/cfg/VAllocStress/VAllocStress.vcxproj
@@ -170,6 +170,9 @@
     </ClCompile>
     <ClCompile Include="VAllocStress.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="VAllocStress.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/cfg/VirtualScan/VirtualScan.manifest
+++ b/cfg/VirtualScan/VirtualScan.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and Windows Server 2016 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+
+      <!-- Windows 8.1 and Windows Server 2012 R2 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}}"/>
+
+      <!-- Windows 8 and Windows Server 2012 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+
+      <!-- Windows 7 and Windows Server 2008 R2 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+
+      <!-- Windows Vista and Windows Server 2008 -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/cfg/VirtualScan/VirtualScan.manifest
+++ b/cfg/VirtualScan/VirtualScan.manifest
@@ -6,7 +6,7 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
 
       <!-- Windows 8.1 and Windows Server 2012 R2 -->
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
 
       <!-- Windows 8 and Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>

--- a/cfg/VirtualScan/VirtualScan.vcxproj
+++ b/cfg/VirtualScan/VirtualScan.vcxproj
@@ -166,6 +166,9 @@
     </ClCompile>
     <ClCompile Include="VirtualScan.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="VirtualScan.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
Added application manifests to increase version helper accuracy (e.g. `IsWindows10OrGreater`), important when compiling with `/D PORTABLE_CODE`