### PR TITLE
Updated NtApiDotNet to v1.1.29 to fix issue #11.

### DIFF
--- a/FindZombieHandles/FindZombieHandles.csproj
+++ b/FindZombieHandles/FindZombieHandles.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NtApiDotNet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\NtApiDotNet.1.1.28\lib\net45\NtApiDotNet.dll</HintPath>
+      <HintPath>packages\NtApiDotNet.1.1.29\lib\net45\NtApiDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/FindZombieHandles/packages.config
+++ b/FindZombieHandles/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NtApiDotNet" version="1.1.28" targetFramework="net461" />
+  <package id="NtApiDotNet" version="1.1.29" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This should fix the issue with querying handles.